### PR TITLE
Area GET correct when size = 0

### DIFF
--- a/controllers/area-controller.js
+++ b/controllers/area-controller.js
@@ -23,6 +23,12 @@ function areasController() {
         lib.getArea(req.params.areacode, function(area) {
             if (area !== null) {
                 var defaultedArea = Object.assign(modeler.area.blank(), area);
+
+                // Check for invalid size values
+                if (typeof(defaultedArea.size) !== 'number' || isNaN(defaultedArea.size)) {
+                    defaultedArea.size = 0;
+                }
+
                 res.json(defaultedArea);
             } else {
                 res.status(404);

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ var apiPreface = '/api';
 var modeler = require('./models/modeler');
 
 // Configure the application
-app.use(morgan('combined'));
+//app.use(morgan('combined'));
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));

--- a/test/area-test.js
+++ b/test/area-test.js
@@ -158,6 +158,31 @@ describe('Area API', function() {
                     done();
                 });
         });
+
+        it('check kobold valley missing size', function(done) {
+            var noSizeKbv = Object.assign({}, koboldValleyArea);
+            delete noSizeKbv.size;
+
+            chai.request(server)
+                .post('/api/area')
+                .send(noSizeKbv)
+                .end(function(err, res) {
+                    res.should.have.status(200);
+
+                    chai.request(server)
+                        .get('/api/area/' + noSizeKbv.areacode)
+                        .end(function(gerr, gres) {
+                            console.log(gres.body);
+                            gres.should.have.status(200);
+                            gres.body.should.be.a('object');
+                            should.exist(gres.body.size);
+                            gres.body.size.should.be.a('number');
+                            expect(gres.body.size).to.equal(0);
+
+                            done();
+                        });
+                });
+        });
     });
 
     describe('PUT Area', function() {


### PR DESCRIPTION
Size was being returned from the API as NaN or null when the property was non-existant.
It should be returning properly now.